### PR TITLE
Add `libunwind` to the toolchain

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -55,6 +55,7 @@ DIST_FLAVORS = {
             ":bins" + suffix,
             "//:builtin_headers_pkg_files",
             "@llvm-raw//:libcxx_include",
+            "@llvm-raw//:unwind",
         ],
         empty_files = props.get("extra_empty_files", []),
         extension = ".tar.xz",

--- a/BUILD.llvm-raw
+++ b/BUILD.llvm-raw
@@ -1,5 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 
@@ -45,4 +46,26 @@ pkg_files(
     ],
     strip_prefix = "libcxx/include",
     prefix = "include/c++/v1",
+)
+
+filegroup(
+    name = "llvm_srcs",
+    srcs = glob(["**"]),
+)
+
+cmake(
+    name = "unwind",
+    lib_source = ":llvm_srcs",
+    working_directory = "llvm",
+    build_args = ["-j10"],
+    generate_args = [
+        "-DCMAKE_BUILD_TYPE=Debug",
+        "-DLLVM_ENABLE_RUNTIMES=libunwind",
+    ],
+    postfix_script = """\
+cp ${BUILD_TMPDIR}/lib/libunwind.a ${INSTALLDIR}/lib
+    """,
+    targets = ["unwind"],
+    out_static_libs = ["libunwind.a"],
+    install = False,
 )

--- a/BUILD.llvm-raw
+++ b/BUILD.llvm-raw
@@ -59,7 +59,7 @@ cmake(
     working_directory = "llvm",
     build_args = ["-j10"],
     generate_args = [
-        "-DCMAKE_BUILD_TYPE=Debug",
+        "-DCMAKE_BUILD_TYPE=Release",
         "-DLLVM_ENABLE_RUNTIMES=libunwind",
     ],
     postfix_script = """\

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1734,6 +1734,25 @@
         ]
       }
     },
+    "@@bazel_tools//tools/osx:xcode_configure.bzl%xcode_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "Qh2bWTU6QW6wkrd87qrU4YeY+SG37Nvw3A0PR4Y0L2Y=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_config_xcode": {
+            "bzlFile": "@@bazel_tools//tools/osx:xcode_configure.bzl",
+            "ruleClassName": "xcode_autoconf",
+            "attributes": {
+              "name": "bazel_tools~xcode_configure_extension~local_config_xcode",
+              "xcode_locator": "@bazel_tools//tools/osx:xcode_locator.m",
+              "remote_xcode": ""
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
     "@@bazel_tools//tools/sh:sh_configure.bzl%sh_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "hp4NgmNjEg5+xgvzfh6L83bt9/aiiWETuNpwNuF1MSU=",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,6 +16,17 @@ http_archive(
     ],
 )
 
+FOREIGN_CC_VERSION = "0.9.0"
+
+http_archive(
+    name = "rules_foreign_cc",
+    sha256 = "",
+    strip_prefix = "rules_foreign_cc-{version}".format(version = FOREIGN_CC_VERSION),
+    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/{version}.tar.gz".format(version = FOREIGN_CC_VERSION),
+)
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
+rules_foreign_cc_dependencies()
+
 LLVM_COMMIT = "26a1d6601d727a96f4301d0d8647b5a42760ae0c"  # 18.1.2
 
 http_archive(


### PR DESCRIPTION
Progress towards https://github.com/dzbarsky/static-clang/issues/1

This PR adds `libunwind` to the toolchain by building it with `cmake` via `rules_foreign_cc`. `libunwind` is an important runtime library for the clang toolchain ([docs](https://clang.llvm.org/docs/Toolchain.html#unwind-library)) and AFAIK is not natively included with macOS. Compiled it is <100Kb so I don't believe it will increase the size of the bundle.

Using my local machine's C toolchain I verified the `libunwind` build succeeds, but I can't get the bundled `zig-cc` toolchain to work. I also tried creating a free Buildbuddy account but that failed with the following error:

```
INFO: Invocation ID: 505ef73e-1616-47f6-be90-b15684758ceb
INFO: Streaming build results to: https://app.buildbuddy.io/invocation/505ef73e-1616-47f6-be90-b15684758ceb
WARNING: Build options --action_env, --experimental_platform_in_output_dir, --extra_execution_platforms, and 4 more have changed, discarding analysis cache (this can be expensive, see https://bazel.build/advanced/performance/iteration-speed).
INFO: Analyzed target //:for_all_platforms (112 packages loaded, 169374 targets configured).
ERROR: /private/var/tmp/_bazel_parker.timmerman/09e98b04a37762c62ebd6addff782992/external/llvm_zstd/BUILD.bazel:22:11: Compiling lib/dictBuilder/divsufsort.c failed: (Exit 1): c++ failed: error executing CppCompile command (from target @@llvm_zstd//:zstd) external/hermetic_cc_toolchain~3.0.1~toolchains~zig_sdk/tools/x86_64-macos-none/c++ -MD -MF bazel-out/darwin_amd64-opt/bin/external/llvm_zstd/_objs/zstd/divsufsort.d ... (remaining 21 arguments skipped)
exec external/hermetic_cc_toolchain~3.0.1~toolchains~zig_sdk/tools/x86_64-macos-none/c++: exec format error
Target //:for_all_platforms failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 21.336s, Critical Path: 13.83s
INFO: 2423 processes: 2390 internal, 4 local, 29 remote.
ERROR: Build did NOT complete successfully
FAILED:
```

@dzbarsky if you can provide guidance for these errors I would be more than happy to get this building locally!