### PR TITLE
add libcxxabi to packages

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -95,6 +95,7 @@ pkg_files(
             ":bins" + suffix,
             "//:builtin_headers_pkg_files",
             "@llvm-raw//:libcxx_include",
+            "@llvm-raw//:libcxxabi_include",
         ] + select({
             "@bazel_tools//src/conditions:darwin": [":libclang_rt.profile_osx"],
             "@bazel_tools//src/conditions:linux_aarch64": [":libclang_rt.profile_aarch64"],

--- a/BUILD.llvm-raw
+++ b/BUILD.llvm-raw
@@ -47,3 +47,12 @@ pkg_files(
     strip_prefix = "libcxx/include",
     prefix = "include/c++/v1",
 )
+
+pkg_files(
+    name = "libcxxabi_include",
+    srcs = glob(["libcxxabi/include/**"], exclude = [
+        "libcxxabi/include/CMakeLists.txt",
+    ]),
+    strip_prefix = "libcxxabi/include",
+    prefix = "include/c++/v1",
+)


### PR DESCRIPTION
@dzbarsky Thank you for merging https://github.com/dzbarsky/static-clang/pull/14

I have another issue I would like to propose a fix for. Some projects we build failed with static-clang because `cxxabi.h` could not be found. 

Would bundling it make sense for you?

I tested these changes locally and the files appear to make it to the right place within the archive:
```
$ tar tf bazel-out/darwin_arm64-opt/bin/dist_minimal.tar.xz | rg 'cxxabi'
include/c++/v1/__cxxabi_config.h
include/c++/v1/cxxabi.h
```

Thanks!